### PR TITLE
Fix periodic table display inverted in RTL mode

### DIFF
--- a/core/editor.css
+++ b/core/editor.css
@@ -67,3 +67,8 @@
         width: 140%;
     }
 }
+
+table.wrs_layoutFor9Rows.wrs_periodicTable {
+    /*rtl:ignore*/
+    direction: ltr;
+}


### PR DESCRIPTION
Hello,
Please review and see if you can merge this fix, for displaying the periodic table properly in RTL mode (which should be the same as in LTR mode)
Nadav