### PR TITLE
KB-3999: Upgrade MathType filter plugin version to match MathType for Atto version

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020070400;
+$plugin->version = 2020080600;
 $plugin->release = '7.18.1';
 $plugin->requires = 2014050800;
 $plugin->component = 'atto_wiris';
-$plugin->dependencies = array ('filter_wiris' => 2020070400);
+$plugin->dependencies = array ('filter_wiris' => 2020080600);
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020022400;
-$plugin->release = '7.18.0';
+$plugin->version = 2020070400;
+$plugin->release = '7.18.1';
 $plugin->requires = 2014050800;
 $plugin->component = 'atto_wiris';
-$plugin->dependencies = array ('filter_wiris' => 2020022400);
+$plugin->dependencies = array ('filter_wiris' => 2020070400);
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The MathType moodle filter plugin and MathType for Atto versions don't match:

This can be checked on this moodle test:

- https://<moodle-address>/filter/wiris/info.php

**Solution**

There are no known incompatibililties between both plugins; everything works fine.
So it's only a matter of updating the version numbers to make them match.

A patch version upgrade is needed on the the affected repositories:

- atto_wiris (this repo)
- tinymce_tiny_mce_wiris
- filter_wiris


Close KB-3999