### PR TITLE
Release 7.26.1 (18th june 2021)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Last release of this plugin is 7.26.0.
+Last release of this plugin is 7.26.1.
 
-## [Unreleased]
+## v7.26.1
 - Feature: 'Migrate MathType plugins suite from TravisCI to Github Actions'.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![MathType](./pix/logo-mathtype.png) MathType Moodle plugin for Atto
 
-[![Build Status](https://travis-ci.com/wiris/moodle-atto_wiris.svg?branch=stable)](https://travis-ci.com/wiris/moodle-atto_wiris)
+[![Moodle Plugin CI](https://github.com/wiris/moodle-atto_wiris/actions/workflows/moodle-ci.yml/badge.svg)](https://github.com/wiris/moodle-atto_wiris/actions/workflows/moodle-ci.yml)
 
 Type and handwrite mathematical notation in Moodle with [MathType](https://www.wiris.com/en/mathtype/) for Atto Editor.
 

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021050600;
-$plugin->release = '7.26.0';
+$plugin->version = 2021061800;
+$plugin->release = '7.26.1';
 $plugin->requires = 2014050800;
 $plugin->component = 'atto_wiris';
-$plugin->dependencies = array ('filter_wiris' => 2021050600);
+$plugin->dependencies = array ('filter_wiris' => 2021061800);
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
### Changelog:

- Feature: 'Migrate MathType plugins suite from TravisCI to Github
  Actions'.

#### Migrate test build machine from TravisCI to Github

- Update CHANGELOG
- Fix lint issues on privacy class.
- Add workflow based on 'moodle-plugin-ci'.
- Remove TravisCI script from the project.
- Update .gitignore with custom paths.
- Update CHANGELOG
- Add full matrix to the tests
- Add Moodle env variables.

See: https://github.com/moodlehq/moodle-plugin-ci