### PR TITLE
Moodle 4.0 Atto plugin Behat tests compatibility

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -49,14 +49,28 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['master']
+        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
           # Exclude Moodle+PHP incompatible versions
           # See: https://docs.moodle.org/dev/Moodle_and_PHP
+          - moodle-branch: 'MOODLE_38_STABLE'
+            php: '7.1'
+          - moodle-branch: 'MOODLE_39_STABLE'
+            php: '7.1'
+          - moodle-branch: 'MOODLE_310_STABLE'
+            php: '7.1'
+          - moodle-branch: 'MOODLE_311_STABLE'
+            php: '7.1'
           - moodle-branch: 'master'
             php: '7.1'
+          - moodle-branch: 'MOODLE_35_STABLE'
+            php: '7.4'
+          - moodle-branch: 'MOODLE_36_STABLE'
+            php: '7.4'
+          - moodle-branch: 'MOODLE_37_STABLE'
+            php: '7.4'
             
     steps:
       # 0. Initial step. Check out this repository code in ./plugin directory
@@ -169,11 +183,18 @@ jobs:
       - name: PHPUnit tests
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit
-      # Run Behat tests on all Moodle branches.
+      # Run Behat tests on latest Moodle branch
       - name: Behat features
-        if: ${{ always() }}
+        if: ${{ matrix.moodle-branch == 'master' }}
         run: moodle-plugin-ci behat --profile default -vvv
-      # Prepare '/var/www/behatfaildumps' in case of error
+      # Run Behat Legacy test on the rest Moodle branchs
+      - name: Behat legacy features
+        if: ${{ matrix.moodle-branch != 'master' }}
+        run: |
+          docker run -d --rm --name=selenium --net=host --shm-size=2g -v /home/runner/work/moodle-atto_wiris/moodle-atto_wiris/moodle:/home/runner/work/moodle-atto_wiris/moodle-atto_wiris/moodle selenium/standalone-chrome:3
+          nohup php -S localhost:8000 -t /home/runner/work/moodle-atto_wiris/moodle-atto_wiris/moodle > phpd.log 2>&1 &
+          php moodle/admin/tool/behat/cli/run.php --tags=@3.x --profile=chrome --suite=default --auto-rerun=2 --verbose -vvv
+          docker stop selenium
 
       # 5.5. Upload snapshots of errors ( Not working )
       # Save videos and screenshots as test artifacts

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -29,7 +29,7 @@ jobs:
     services:
       # The test will be scoped to postgres only.
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -49,38 +49,14 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE']
+        moodle-branch: ['master']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
           # Exclude Moodle+PHP incompatible versions
           # See: https://docs.moodle.org/dev/Moodle_and_PHP
-          - moodle-branch: 'MOODLE_38_STABLE'
+          - moodle-branch: 'master'
             php: '7.1'
-          - moodle-branch: 'MOODLE_39_STABLE'
-            php: '7.1'
-          - moodle-branch: 'MOODLE_310_STABLE'
-            php: '7.1'
-          - moodle-branch: 'MOODLE_311_STABLE'
-            php: '7.1'
-          - moodle-branch: 'MOODLE_35_STABLE'
-            php: '7.4'
-          - moodle-branch: 'MOODLE_36_STABLE'
-            php: '7.4'
-          - moodle-branch: 'MOODLE_37_STABLE'
-            php: '7.4'
-          - moodle-branch: 'MOODLE_35_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_36_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_37_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_38_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_39_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_310_STABLE'
-            php: '8.0'
             
     steps:
       # 0. Initial step. Check out this repository code in ./plugin directory
@@ -134,7 +110,6 @@ jobs:
       - name: Add MathtType filter plugin
         run: |
           moodle-plugin-ci add-plugin --branch ${GITHUB_REF##*/} wiris/moodle-filter_wiris
-
       # 4. Install Moodle-plugin-ci
       - name: Install moodle-plugin-ci
         run: |

--- a/tests/behat/atto_UTF-32.feature
+++ b/tests/behat/atto_UTF-32.feature
@@ -18,8 +18,7 @@ I need to see a formula with a UTF-32 character
 
   @javascript
   Scenario: Insert double struck using UTF-32
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I set the field "Toolbar config" to multiline:
     """
     math = wiris
@@ -32,6 +31,7 @@ I need to see a formula with a UTF-32 character
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mi mathvariant="normal">&#x1D540;</mi></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "HTML" in "Page content" field in Atto editor
     And I press "HTML pressed" in "Page content" field in Atto editor

--- a/tests/behat/atto_UTF-32.feature
+++ b/tests/behat/atto_UTF-32.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Test I double struck (UTF-32)
 In order to create formulas with UTF-32 characters
 As an admin

--- a/tests/behat/atto_assignmentsGiveFeedback.feature
+++ b/tests/behat/atto_assignmentsGiveFeedback.feature
@@ -36,10 +36,11 @@ Feature: Formulas are rendered on an Assignment feedback
     And I should see "Grade"
     # A super shitty-wat to click on the 'Grade' link since "I press" and 'I click on "Grade" "link"' don't work.
     # And I click on "Grade" "link" # Does not work.
-    And I click on ".btn-primary" "css_element" in the "//div[@class='submissionlinks']" "xpath_element"
+    And I click on ".btn-primary" "css_element" in the "//div[@class='row']" "xpath_element"
     # 02. Grade the assignment.
     And I click on "MathType" "button"
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     Then I press "Save changes"
     # 03. Validate the formula is rendered on both contexts.

--- a/tests/behat/atto_changeEditor.feature
+++ b/tests/behat/atto_changeEditor.feature
@@ -26,9 +26,11 @@ I need to change between editors
     And I set the following fields to these values:
       | Name | Test MathType for Atto on Moodle chemistry formulas |
     And I press "ChemType" in "Page content" field in Atto editor
+    And I wait "1" seconds
     And I press cancel button in MathType Editor
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     Then I wait until Wirisformula formula exists

--- a/tests/behat/atto_changeEditor.feature
+++ b/tests/behat/atto_changeEditor.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Change between editors
 In order to check if it's possible change between MathType and ChemType editors
 As an admin

--- a/tests/behat/atto_chemistryModal.feature
+++ b/tests/behat/atto_chemistryModal.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Use atto to post a chemistry formula
 In order to check whether a chemistry formula can be displayed correctly
 As an admin

--- a/tests/behat/atto_chemistryModal.feature
+++ b/tests/behat/atto_chemistryModal.feature
@@ -27,6 +27,7 @@ I need to write a chemistry formula
       | Name | Test MathType for Atto on Moodle chemistry formulas |
     And I press "ChemType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mi mathvariant="normal">H</mi><mn>2</mn><mi mathvariant="normal">O</mi></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     Then I wait until Wirisformula formula exists

--- a/tests/behat/atto_dbClickNonFormulaImages.feature
+++ b/tests/behat/atto_dbClickNonFormulaImages.feature
@@ -21,12 +21,10 @@ when it is opened.
   @javascript
   Scenario: Post a chemistry formula
     # Set enabled plugins.
-    And I navigate to "Site administration" in site administration
-    And I follow "Site security settings"
+    And I navigate to "General > Security > Site security settings" in site administration
     And I check enable trusted content
     And I press "Save changes"
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I set the field "Toolbar config" to multiline:
     """
     files = image
@@ -41,12 +39,14 @@ when it is opened.
     # Insert formula.
     And I press "ChemType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mi mathvariant="normal">H</mi><mn>2</mn><mi mathvariant="normal">O</mi></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     # Insert non-formula image.
     And I select the text in the "Page content" Atto editor
     And I click on "Insert or edit image" "button"
     And I set the field "Enter URL" to "https://i.ytimg.com/vi/MPV2METPeJU/maxresdefault.jpg"
     And I set the field "Describe this image for someone who cannot see it" to "Dog"
+    And I wait "1" seconds
     And I click on "Save image" "button"
     # Assert that dbClick works
     And I dbClick on image with alt equals to "Dog"

--- a/tests/behat/atto_emptyLatex.feature
+++ b/tests/behat/atto_emptyLatex.feature
@@ -18,12 +18,10 @@ I need to edit an empty LaTeX with MathType
 
   @javascript
   Scenario: Insert MathType formula to an empty LaTeX
-    And I navigate to "Site administration" in site administration
-    And I follow "Site security settings"
+    And I navigate to "General > Security > Site security settings" in site administration
     And I check enable trusted content
     And I press "Save changes"
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I set the field "Toolbar config" to multiline:
     """
     other = html
@@ -39,6 +37,7 @@ I need to edit an empty LaTeX with MathType
     And I place caret at position "2" in "Page content" field
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     Then "$$\frac1{\sqrt{2\pi}}$$" "text" should exist
     And I press "HTML" in "Page content" field in Atto editor
@@ -48,5 +47,5 @@ I need to edit an empty LaTeX with MathType
     Then I wait until Wirisformula formula exists
     Then a Wirisformula containing 'square root' should exist
     And Wirisformula should has height 48 with error of 2
-    And I navigate to "Edit settings" in current page administration
+    And I navigate to "Settings" in current page administration
     Then "$$\frac1{\sqrt{2\pi}}$$" "text" should exist

--- a/tests/behat/atto_filterActivityDisabled.feature
+++ b/tests/behat/atto_filterActivityDisabled.feature
@@ -31,8 +31,8 @@ I need not to be able to use MathType if filter is disabled
     And I navigate to "Filters" in current page administration
     And I turn MathType filter off
     And I press "Save changes"
-    And I follow "Test MathType for Atto on Moodle"
-    And I navigate to "Edit settings" in current page administration
+    And I click on "Back to Page: Test MathType for Atto on Moodle" "link"
+    And I navigate to "Settings" in current page administration
     Then "MathType" "button" should not exist
 
   @javascript

--- a/tests/behat/atto_filterCourseEnabled.feature
+++ b/tests/behat/atto_filterCourseEnabled.feature
@@ -28,8 +28,7 @@ I need to use MathType despite the filter is disabled
     And I am on "Course 1" course homepage
     And I add a "Page" to section "0"
     Then "MathType" "button" should not exist
-    And I navigate to "Plugins" in site administration
-    And I follow "MathType by WIRIS"
+    And I navigate to "Plugins > Filters > MathType by WIRIS" in site administration
     And I check editor always active
     And I press "Save changes"
     And I am on "Course 1" course homepage

--- a/tests/behat/atto_filterCourseEnabled.feature
+++ b/tests/behat/atto_filterCourseEnabled.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Check MathType enabled if filter disabled at course level but allow_editorplugin_active_course setting is enabled
 In order to use MathType with other filters
 As an admin

--- a/tests/behat/atto_frenchQuotes.feature
+++ b/tests/behat/atto_frenchQuotes.feature
@@ -27,5 +27,4 @@ I need to post with french quotes
       | Page content | &laquo;Bonjour&raquo; |
     And I press "Save and display"
     Then "«Bonjour»" "text" should exist
-    And I navigate to "Edit settings" in current page administration
     Then Wirisformula should not exist

--- a/tests/behat/atto_frenchQuotes.feature
+++ b/tests/behat/atto_frenchQuotes.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Checking french quotes to prevent dissapear and post
 In order to check if french quotes can be displayed correctly
 I need to post with french quotes

--- a/tests/behat/atto_modal.feature
+++ b/tests/behat/atto_modal.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Use atto to post
 In order to check if MathType formula can be displayed correctly
 As an admin

--- a/tests/behat/atto_modal.feature
+++ b/tests/behat/atto_modal.feature
@@ -27,6 +27,7 @@ I need to create a MathType formula
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     Then I wait until Wirisformula formula exists

--- a/tests/behat/atto_modalDragFocus.feature
+++ b/tests/behat/atto_modalDragFocus.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Verify that we have focus after move modal window
 In order to write Mathematical formulas properly
 As an admin

--- a/tests/behat/atto_modalDragFocus.feature
+++ b/tests/behat/atto_modalDragFocus.feature
@@ -28,6 +28,7 @@ I need to use the modal window
     And I press "MathType" in "Page content" field in Atto editor
     And I click on MathType editor title bar
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     Then I wait until Wirisformula formula exists

--- a/tests/behat/atto_multipleEditorsTextAarea.feature
+++ b/tests/behat/atto_multipleEditorsTextAarea.feature
@@ -18,8 +18,7 @@ I need to re-edit formulas in a question type form
 
   @javascript
   Scenario: Create and answer a Quiz using formulas
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I set the field "Toolbar config" to multiline:
     """
     math = wiris
@@ -30,24 +29,26 @@ I need to re-edit formulas in a question type form
     And I add a "Quiz" to section "1"
     And I set the following fields to these values:
       | Name | Quiz 1 |
-    And I press "Save and return to course"
-    And I follow "Quiz 1"
-    And I press "Edit quiz"
-    And I open the action menu in ".page-add-actions" "css_element"
-
-    And I follow "a new question"
+    And I press "Save and display"
+    And I click on "Add question" "link"
+    And I click on "Edit mode" "checkbox"
+    And I click on "Add" "link"
+    And I click on "a new question" "link"
     And I choose Short answer
     And I press "submitbutton"
     And I press "MathType" in "Question text" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mn>2</mn></msqrt></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "HTML" in "Question text" field in Atto editor
     And I press "MathType" in "General feedback" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mn>3</mn></msqrt></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "HTML" in "General feedback" field in Atto editor
     And I press "MathType" in "Feedback" field in Atto editor
     And I set MathType formula to '<math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mn>4</mn></msqrt></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "HTML" in "Feedback" field in Atto editor
     Then I wait until Wirisformula formula exists
@@ -62,8 +63,8 @@ I need to re-edit formulas in a question type form
       | Answer 1 | 10 |
     And I select 100% option in Answer1
     And I press "submitbutton"
-    And I follow "Quiz 1"
-    And I navigate to "Preview" in current page administration
+    And I navigate to "Quiz" in current page administration
+    And I click on "Attempt quiz" "button"
     Then I wait until Wirisformula formula exists
     # Then a Wirisformula containing 'square root of 2' should exist
     And I set the field "Answer" to "10"

--- a/tests/behat/atto_restoreDraft.feature
+++ b/tests/behat/atto_restoreDraft.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @wiris_mathtype @3.x
 Feature: Check that formula is rendered when atto's draft is restored
 In order to not loose data
 As an admin

--- a/tests/behat/atto_restoreDraft.feature
+++ b/tests/behat/atto_restoreDraft.feature
@@ -21,8 +21,7 @@ I need to restore draft content containing MathType formulas
 
   @javascript
   Scenario: Insert a formula and restore the page
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I select seconds in autosave frequency option
     And I press "Save changes"
     And I am on "Course 1" course homepage with editing mode on
@@ -31,6 +30,7 @@ I need to restore draft content containing MathType formulas
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I wait "5" seconds
     And I reload the page

--- a/tests/behat/atto_settingMathChemButtonEditorVisibility.feature
+++ b/tests/behat/atto_settingMathChemButtonEditorVisibility.feature
@@ -1,4 +1,4 @@
-@filter @filter_wiris @filter_wiris_settings @wiris_settings @wiris_mathtype @atto @atto_wiris @wiris_mathtype_01
+@filter @filter_wiris @filter_wiris_settings @wiris_settings @wiris_mathtype @atto @atto_wiris @wiris_mathtype_01 @3.x
 Feature: Check the math and chem buttons visibility on text editors
 In order to check the buttons visibility in atto editor
 As an admin

--- a/tests/behat/atto_textArea.feature
+++ b/tests/behat/atto_textArea.feature
@@ -1,4 +1,4 @@
-@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @atto_wiris_bug01 @wiris_mathtype
+@editor @editor_atto @atto @atto_wiris @_bug_phantomjs @atto_wiris_bug01 @wiris_mathtype @3.x
 Feature: Check if the raw code generated in html contains MathML instead of safeXML
 In order to edit HTML code
 As an admin

--- a/tests/behat/atto_textArea.feature
+++ b/tests/behat/atto_textArea.feature
@@ -18,8 +18,7 @@ I need to not loose data editing HTML code
 
   @javascript
   Scenario: Transform formula to raw code in html
-    And I navigate to "Plugins" in site administration
-    And I follow "Atto toolbar settings"
+    And I navigate to "Plugins > Text editors > Atto toolbar settings" in site administration
     And I set the field "Toolbar config" to multiline:
     """
     math = wiris
@@ -32,6 +31,7 @@ I need to not loose data editing HTML code
       | Name | Test MathType for Atto on Moodle |
     And I press "MathType" in "Page content" field in Atto editor
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>20</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
+    And I wait "1" seconds
     And I press accept button in MathType Editor
     # And I press "HTML" in "Page content" field in Atto editor
     # Then I wait until Wirisformula formula exists


### PR DESCRIPTION
## Description 
The main goal of this task is to make all Behat test compatible with Moodle 4.0 branch. And If it is possible, make also the test compatible with the previous Moodle (3.x)  supported  version.

### Included on this PR:

-    Updated Behat test to be compatible with Moodle 4.0 branch.
-    Added tag `@atto_wiris_legacy` to all the test that are compatible with the oldest Moodle (3.x) versions.
-    Updated the moodle-ci.yml:
      -    Now all Behat test will be run on the latest Moodle version (currently master). The rest of Moodle versions from workflow 
      matrix will just run the legacy Behat tests.

### Behat Tests:

- Have been updated 14 Behat test in order to be compatible with Moodle 4.0. 
- Next tests are now incompatible with the oldest Moodle (3.x) versions:
    - atto_assignmentsGiveFeedback
    - atto_dbClickNonFormulaImages
    - atto_emptyLatex
    - atto_filterActivityDisabled
    - atto_multipleEditorsTextAarea
- The compatible test have now the tag `@atto_wiris_legacy`.

### GitHub actions workflow:

- Just the `master` Moodle branch run all Behat tests.

> Will be updated to MOODLE_40_STABLE when Moodle frezze the code.

- Added step `Behat legacy features` to run the Behat tests with `@atto_wiris_legacy` tag on the rest of Moodle (3.x) versions.

## How to reproduce:

1. Go to [moodle-atto_wiris github repository Actions section.](https://github.com/wiris/moodle-atto_wiris/actions)
3. Select the `Moodle Plugin CI` workflow.
4. Click on `Run workflow` and select the branch `moodle40`.
5. Click on the `Run workflow` green button.

---

[#taskid 21990](https://wiris.kanbanize.com/ctrl_board/2/cards/21990/comments/)
