### PR TITLE
[Fix] MathType filter not working on LaTeX formulas in student text fields

### DIFF
--- a/yui/build/moodle-atto_wiris-button/moodle-atto_wiris-button-debug.js
+++ b/yui/build/moodle-atto_wiris-button/moodle-atto_wiris-button-debug.js
@@ -151,8 +151,8 @@ Y.namespace('M.atto_wiris').Button = Y.Base.create('button', Y.M.editor_atto.Edi
                     // and convert images into data-mathml attribute.
                     var html = host.editor.get('innerHTML');
                     // Check if exist mathml tag for parse.
-                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0) {
-                        host.textarea.set('value', WirisPlugin.Parser.endParse(html, null, this.config.lang, true));
+                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0 || html.indexOf('$$') >= 0) {
+                        host.textarea.set('value', WirisPlugin.Parser.endParseSaveMode(html, null, this.config.lang, true));
                     }
                 };
 

--- a/yui/build/moodle-atto_wiris-button/moodle-atto_wiris-button.js
+++ b/yui/build/moodle-atto_wiris-button/moodle-atto_wiris-button.js
@@ -150,8 +150,8 @@ Y.namespace('M.atto_wiris').Button = Y.Base.create('button', Y.M.editor_atto.Edi
                     // and convert images into data-mathml attribute.
                     var html = host.editor.get('innerHTML');
                     // Check if exist mathml tag for parse.
-                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0) {
-                        host.textarea.set('value', WirisPlugin.Parser.endParse(html, null, this.config.lang, true));
+                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0 || html.indexOf('$$') >= 0) {
+                        host.textarea.set('value', WirisPlugin.Parser.endParseSaveMode(html, null, this.config.lang, true));
                     }
                 };
 

--- a/yui/src/button/js/button.js
+++ b/yui/src/button/js/button.js
@@ -149,8 +149,8 @@ Y.namespace('M.atto_wiris').Button = Y.Base.create('button', Y.M.editor_atto.Edi
                     // and convert images into data-mathml attribute.
                     var html = host.editor.get('innerHTML');
                     // Check if exist mathml tag for parse.
-                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0) {
-                        host.textarea.set('value', WirisPlugin.Parser.endParse(html, null, this.config.lang, true));
+                    if (html.indexOf('math»') >= 0 || html.indexOf('math>') >= 0 || html.indexOf('$$') >= 0) {
+                        host.textarea.set('value', WirisPlugin.Parser.endParseSaveMode(html, null, this.config.lang, true));
                     }
                 };
 


### PR DESCRIPTION
## Description

The MathType filter for Moodle doesn't render LaTex formulas to MathType if they are written in student text fields. Insted, they get corrupted.

This PR solves the mentioned issue with the same behaviour as the Moodle default parser, MathJax.

## Steps to reproduce

1. Open a new Moodle instance with the changes on this PR.
2. Change to student role.
3. In a student field (for example, a forum), write a latex formula.
4. Validate that is rendered properly.

---
[#taskid 4878](https://wiris.kanbanize.com/ctrl_board/2/cards/4878/details/)