### PR TITLE
test: fix mtmoodle-90

### DIFF
--- a/tests/behat/atto_userInsertsChemTypeFormula.feature
+++ b/tests/behat/atto_userInsertsChemTypeFormula.feature
@@ -26,7 +26,7 @@ I need to write a ChemType formula
     And I set the following fields to these values:
       | Name | Test MathType for Atto on Moodle chemistry formulas |
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
+    And I wait until ChemType editor is displayed
     And I set MathType formula to '<math><mi mathvariant="normal">H</mi><mn>2</mn><mi mathvariant="normal">O</mi></math>'
     And I wait "3" seconds
     And I press accept button in MathType Editor

--- a/tests/behat/atto_validateInsertingFormulaAfterSwitchingEditors.feature
+++ b/tests/behat/atto_validateInsertingFormulaAfterSwitchingEditors.feature
@@ -46,7 +46,7 @@ Feature: Insert MathType formula after editor switch
     And I set the following fields to these values:
       | Name | Test Multiple Editors for Atto on Moodle |
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
+    And I wait until ChemType editor is displayed
     And I wait "2" seconds
     And I press "MathType" in "Page content" field in Atto editor
     And I wait "1" seconds

--- a/tests/behat/atto_validateSwitchBetweenEditors.feature
+++ b/tests/behat/atto_validateSwitchBetweenEditors.feature
@@ -26,12 +26,10 @@ Feature: MathType and ChemType editor switch
     And I set the following fields to these values:
       | Name | Test switching between editors |
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
-    And I press cancel button in MathType Editor
+    And I wait until ChemType editor is displayed
     And I press "MathType" in "Page content" field in Atto editor
     And I wait until MathType editor is displayed
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
-    And I wait "1" seconds
     And I press accept button in MathType Editor
     And I press "Save and display"
     And I wait "1" seconds
@@ -47,9 +45,8 @@ Feature: MathType and ChemType editor switch
       | Name | Test switching between editors |
     And I press "MathType" in "Page content" field in Atto editor
     And I wait until MathType editor is displayed
-    And I press cancel button in MathType Editor
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
+    And I wait until ChemType editor is displayed
     And I set MathType formula to '<math><mi mathvariant="normal">H</mi><mn>2</mn><mi mathvariant="normal">O</mi></math>'
     And I wait "1" seconds
     And I press accept button in MathType Editor
@@ -65,8 +62,7 @@ Feature: MathType and ChemType editor switch
     And I set the following fields to these values:
       | Name | Test switching between editors |
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
-    And I press cancel button in MathType Editor
+    And I wait until ChemType editor is displayed
     And I press "MathType" in "Page content" field in Atto editor
     And I wait until MathType editor is displayed
     And I set MathType formula to '<math><mfrac><mn>1</mn><msqrt><mn>2</mn><mi>&#x3c0;</mi></msqrt></mfrac></math>'
@@ -85,9 +81,8 @@ Feature: MathType and ChemType editor switch
       | Name | Test switching between editors |
     And I press "MathType" in "Page content" field in Atto editor
     And I wait until MathType editor is displayed
-    And I press cancel button in MathType Editor
     And I press "ChemType" in "Page content" field in Atto editor
-    And I wait until MathType editor is displayed
+    And I wait until ChemType editor is displayed
     And I set MathType formula to '<math><mi mathvariant="normal">H</mi><mn>2</mn><mi mathvariant="normal">O</mi></math>'
     And I press accept button in MathType Editor
     And I press "Save and display"


### PR DESCRIPTION
Fix test:

Deleted step to press on Cancel button
Fixed “Cancel button” function (it was pressing accept button)
Added function to check if ChemType is opened instead of MathType and changed the verification after opening it. Updated a few tests that were using the MT function instead of the CT function

https://wiris.kanbanize.com/ctrl_board/2/cards/50411/details/