### PR TITLE
fix: pass phpbcf moodle-extra

### DIFF
--- a/.github/workflows/moodle-ci-lint.yml
+++ b/.github/workflows/moodle-ci-lint.yml
@@ -76,7 +76,7 @@ jobs:
       # 3.3. Code validations
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 30 ./plugin
+        run: moodle-plugin-ci codechecker ./plugin
 
       - name: Check upgrade savepoints
         if: ${{ always() }}


### PR DESCRIPTION
## Description

This removes the cap of max warnings, as warnings are not as important. We just delete the limit and ran the phpbcf on local

## Type of Change

- [x] Chore (non-breaking change that doesn't add any functionality)

## Checklist

- [X] My changes generate no new warnings or errors

## How should be tested? (Manual or Automated Tests)

Nothing to test